### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/carts-uiet/cartsbusboarding.png?label=ready&title=Ready)](https://waffle.io/carts-uiet/cartsbusboarding)
 CARTS
 =================================================
 [![Build Status](https://travis-ci.org/carts-uiet/cartsbusboarding.svg)](https://travis-ci.org/carts-uiet/cartsbusboarding)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/carts-uiet/cartsbusboarding

This was requested by a real person (user shubhamchaudhary) on waffle.io, we're not trying to spam you.
